### PR TITLE
IllegalArgumentException instead of RunTime.

### DIFF
--- a/src/main/java/com/transferwise/terra/Terra.java
+++ b/src/main/java/com/transferwise/terra/Terra.java
@@ -1,32 +1,19 @@
 package com.transferwise.terra;
 
+import com.transferwise.utils.Fields;
+import com.transferwise.utils.Maps;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
 import org.objenesis.instantiator.ObjectInstantiator;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
 import java.util.Map;
 
 public class Terra {
     private static final Objenesis objenesis = new ObjenesisStd();
 
     public static <T> T hydrate(Class<?> clazz, Object... pairs) {
-        return hydrate(clazz, toMap(pairs));
-    }
-
-    private static Map<String, Object> toMap(Object[] pairs) {
-        if (pairs.length % 2 != 0) {
-            throw new IllegalArgumentException("Number of pairs should be even");
-        }
-
-        Map<String, Object> map = new HashMap<>();
-        for (int i = 0; i < pairs.length;) {
-            map.put((String) pairs[i], pairs[i + 1]);
-            i += 2;
-        }
-
-        return map;
+        return hydrate(clazz, Maps.toMap(pairs));
     }
 
     @SuppressWarnings("unchecked")
@@ -34,7 +21,7 @@ public class Terra {
         ObjectInstantiator instantiator = objenesis.getInstantiatorOf(clazz);
         T object = (T) instantiator.newInstance();
 
-        Map<String, Field> fields = extractFields(clazz);
+        Map<String, Field> fields = Fields.extractFields(clazz);
         for (Map.Entry<String, Object> entry: properties.entrySet()){
             String fieldName = entry.getKey();
             if (!fields.containsKey(fieldName)) {
@@ -53,17 +40,4 @@ public class Terra {
         return object;
     }
 
-    private static Map<String, Field> extractFields(Class<?> clazz) {
-        Map<String, Field> fields = new HashMap<>();
-
-        Class<?> i = clazz;
-        while (i != null && i != Object.class) {
-            for (Field f : i.getDeclaredFields()) {
-                fields.put(f.getName(), f);
-            }
-            i = i.getSuperclass();
-        }
-
-        return fields;
-    }
 }

--- a/src/main/java/com/transferwise/terra/Terra.java
+++ b/src/main/java/com/transferwise/terra/Terra.java
@@ -17,7 +17,7 @@ public class Terra {
 
     private static Map<String, Object> toMap(Object[] pairs) {
         if (pairs.length % 2 != 0) {
-            throw new RuntimeException("Number of pairs should be even");
+            throw new IllegalArgumentException("Number of pairs should be even");
         }
 
         Map<String, Object> map = new HashMap<>();
@@ -38,7 +38,7 @@ public class Terra {
         for (Map.Entry<String, Object> entry: properties.entrySet()){
             String fieldName = entry.getKey();
             if (!fields.containsKey(fieldName)) {
-                throw new RuntimeException("Field " + fieldName + " does not exist in object");
+                throw new IllegalArgumentException("Field " + fieldName + " does not exist in object");
             }
 
             Field f = fields.get(fieldName);

--- a/src/main/java/com/transferwise/utils/Fields.java
+++ b/src/main/java/com/transferwise/utils/Fields.java
@@ -1,0 +1,24 @@
+package com.transferwise.utils;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Samsung on 05/05/2017.
+ */
+public class Fields {
+    public static Map<String, Field> extractFields(Class<?> clazz) {
+        Map<String, Field> fields = new HashMap<>();
+
+        Class<?> i = clazz;
+        while (i != null && i != Object.class) {
+            for (Field f : i.getDeclaredFields()) {
+                fields.put(f.getName(), f);
+            }
+            i = i.getSuperclass();
+        }
+
+        return fields;
+    }
+}

--- a/src/main/java/com/transferwise/utils/Maps.java
+++ b/src/main/java/com/transferwise/utils/Maps.java
@@ -1,0 +1,25 @@
+package com.transferwise.utils;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Samsung on 05/05/2017.
+ */
+public class Maps {
+    public static Map<String, Object> toMap(Object[] pairs) {
+        if (pairs == null || pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Number of pairs should be different than null and even");
+        }
+
+        Map<String, Object> map = new HashMap<>();
+        for (int i = 0; i < pairs.length;) {
+            map.put((String) pairs[i], pairs[i + 1]);
+            i += 2;
+        }
+
+        return map;
+    }
+
+}

--- a/src/test/java/com/transferwise/utils/FieldsTest.java
+++ b/src/test/java/com/transferwise/utils/FieldsTest.java
@@ -1,0 +1,28 @@
+package com.transferwise.utils;
+
+import com.transferwise.terra.TerraTest;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by Samsung on 05/05/2017.
+ */
+public class FieldsTest {
+    @Test
+    public void sholdExtractFields(){
+
+        Map<String, Field> f = Fields.extractFields(String.class);
+
+        assertThat(f.get("serialPersistentFields"), is(notNullValue()));
+        assertThat(f.get("CASE_INSENSITIVE_ORDER"), is(notNullValue()));
+        assertThat(f.get("serialVersionUID"), is(notNullValue()));
+        assertThat(f.get("value"), is(notNullValue()));
+        assertThat(f.get("hash"), is(notNullValue()));
+
+    }
+}

--- a/src/test/java/com/transferwise/utils/MapsTest.java
+++ b/src/test/java/com/transferwise/utils/MapsTest.java
@@ -1,0 +1,34 @@
+package com.transferwise.utils;
+
+import org.junit.Test;
+
+/**
+ * Created by Samsung on 05/05/2017.
+ */
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MapsTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldFailOnNonExistentPairs(){
+        Maps.toMap(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itShouldFailOnOddValues(){
+        String[] pairs = {"a", "1", "b"};
+        Maps.toMap(pairs);
+    }
+
+    @Test
+    public void shouldMapPairs(){
+        String[] pairs = {"a", "1", "b", "2"};
+        Map<String, Object> map = Maps.toMap(pairs);
+        assertThat(map.get("a"), is("1"));
+        assertThat(map.get("b"), is("2"));
+    }
+}


### PR DESCRIPTION
Update exception to IllegalArgumentException instead of RunTime.

I know this update is very simple but make sense.

These two points are about number of arguments and IllegalArgumentException seams to be a little bit better than just throw a runtime.